### PR TITLE
Fix dark mode persistence

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -28,8 +28,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   });
   
   const [isDarkMode, setIsDarkModeState] = useState(() => {
-    return document.documentElement.classList.contains('dark') || 
-           window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const stored = localStorage.getItem('darkMode');
+    if (stored !== null) {
+      return stored === 'true';
+    }
+    return (
+      document.documentElement.classList.contains('dark') ||
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    );
   });
 
   const [backgroundType, setBackgroundTypeState] = useState(() => {


### PR DESCRIPTION
## Summary
- ensure SettingsContext reads `darkMode` from localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68411d173e488333a18bcdce8bb5cc6a