### PR TITLE
Update README cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The only requirement is having Node.js & npm installed - [install with nvm](http
 Follow these steps:
 
 ```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
+# Step 1: Clone the repository.
+git clone https://github.com/BA-CalderonMorales/shadow-scroll-blossom.git
 
 # Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
+cd shadow-scroll-blossom
 
 # Step 3: Install the necessary dependencies.
 npm i


### PR DESCRIPTION
## Summary
- fix README instructions to use `shadow-scroll-blossom`
- replace placeholder repo URL with actual GitHub URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684120f450548333a19a1dfdb155f2dc