### PR TITLE
Fix dark mode persistence

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -32,10 +32,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     if (stored !== null) {
       return stored === 'true';
     }
-    return (
-      document.documentElement.classList.contains('dark') ||
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-    );
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
 
   const [backgroundType, setBackgroundTypeState] = useState(() => {
@@ -81,7 +78,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     } else {
       document.documentElement.classList.remove('dark');
     }
-  }, []);
+  }, [isDarkMode]);
 
   return (
     <SettingsContext.Provider value={{ 


### PR DESCRIPTION
## Summary
- restore dark mode from `localStorage` before using system preference
- update effect dependency so DOM classes match the restored value

## Testing
- `npm install`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684120f17bd4833394bc56a8ce7efc39