### PR TITLE
Add interactive fluid background

### DIFF
--- a/src/components/CanvasBackground.tsx
+++ b/src/components/CanvasBackground.tsx
@@ -10,6 +10,7 @@ interface CanvasBackgroundProps {
 const CanvasBackground: React.FC<CanvasBackgroundProps> = ({ backgroundType, isDarkMode }) => {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [currentBackground, setCurrentBackground] = useState(backgroundType);
+  const [pointerPos, setPointerPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
 
   useEffect(() => {
     if (currentBackground !== backgroundType) {
@@ -25,18 +26,36 @@ const CanvasBackground: React.FC<CanvasBackgroundProps> = ({ backgroundType, isD
     }
   }, [backgroundType, currentBackground]);
 
+  useEffect(() => {
+    if (currentBackground !== 'fluid') return;
+    const updatePos = (e: PointerEvent) => {
+      setPointerPos({ x: e.clientX, y: e.clientY });
+      document.documentElement.style.setProperty('--x', `${e.clientX}px`);
+      document.documentElement.style.setProperty('--y', `${e.clientY}px`);
+    };
+    window.addEventListener('pointermove', updatePos);
+    return () => window.removeEventListener('pointermove', updatePos);
+  }, [currentBackground]);
+
   const backgroundStyle = getBackgroundStyle(currentBackground, isDarkMode);
   const backgroundSize = getBackgroundSize(currentBackground);
+
+  const dynamicStyle = currentBackground === 'fluid'
+    ? {
+        background: getBackgroundStyle('fluid', isDarkMode),
+        backgroundSize
+      }
+    : {
+        background: backgroundStyle,
+        backgroundSize
+      };
 
   return (
     <div 
       className={`absolute inset-0 transition-opacity duration-300 ${
         isTransitioning ? 'opacity-0' : 'opacity-100'
       }`}
-      style={{ 
-        background: backgroundStyle,
-        backgroundSize: backgroundSize
-      }}
+      style={dynamicStyle}
     />
   );
 };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -64,6 +64,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setBackgroundTypeState(type);
     localStorage.setItem('backgroundType', type);
     console.log('Background type changed to:', type);
+    if (type === 'fluid') {
+      setTrackingTypeState('none');
+      localStorage.setItem('trackingType', 'none');
+    }
   };
 
   const setParticleStyle = (style: string) => {

--- a/src/data/settingsOptions.ts
+++ b/src/data/settingsOptions.ts
@@ -18,7 +18,7 @@ export const backgroundOptions = [
   { value: 'matrix', label: 'Digital Matrix', description: 'Flowing code patterns' },
   { value: 'aurora', label: 'Aurora Borealis', description: 'Dancing northern lights' },
   { value: 'synthwave', label: 'Synthwave', description: 'Retro 80s neon vibes' },
-  { value: 'ocean', label: 'Deep Ocean', description: 'Underwater light rays' }
+  { value: 'fluid', label: 'Interactive Fluid', description: 'Flowing neutral ripples' }
 ];
 
 export const particleStyleOptions = [

--- a/src/utils/__tests__/backgroundUtils.test.ts
+++ b/src/utils/__tests__/backgroundUtils.test.ts
@@ -22,4 +22,10 @@ describe('getBackgroundStyle', () => {
     const result = getBackgroundStyle('none', false);
     expect(result).toBe('radial-gradient(circle at center, #f8fafc 0%, #e2e8f0 100%)');
   });
+
+  test('returns fluid style uses css vars', () => {
+    const result = getBackgroundStyle('fluid', true);
+    expect(result).toContain('var(--x');
+    expect(result).toContain('var(--y');
+  });
 });

--- a/src/utils/backgroundUtils.ts
+++ b/src/utils/backgroundUtils.ts
@@ -79,19 +79,15 @@ export const getBackgroundStyle = (backgroundType: string, isDarkMode: boolean):
           linear-gradient(180deg, #fdf4ff 0%, #f3e8ff 100%)
         `;
 
-    case 'ocean':
+    case 'fluid':
       return isDarkMode
         ? `
-          radial-gradient(ellipse at 30% 20%, rgba(0, 191, 255, 0.5) 0%, rgba(30, 144, 255, 0.3) 40%, transparent 80%),
-          radial-gradient(ellipse at 70% 80%, rgba(30, 144, 255, 0.4) 0%, rgba(0, 100, 200, 0.2) 50%, transparent 85%),
-          radial-gradient(ellipse at 50% 50%, rgba(0, 100, 200, 0.3) 0%, rgba(25, 25, 112, 0.15) 60%, transparent 90%),
-          radial-gradient(ellipse at 20% 60%, rgba(72, 209, 204, 0.25) 0%, transparent 70%),
-          linear-gradient(180deg, #001122 0%, #002244 25%, #003366 50%, #002255 75%, #001133 100%)
+          radial-gradient(circle at var(--x, 50%) var(--y, 50%), rgba(107, 114, 128, 0.6) 0%, rgba(17, 24, 39, 0.8) 70%),
+          linear-gradient(180deg, #1f2937 0%, #111827 100%)
         `
         : `
-          radial-gradient(ellipse at 30% 20%, rgba(0, 191, 255, 0.15) 0%, transparent 70%),
-          radial-gradient(ellipse at 70% 80%, rgba(30, 144, 255, 0.12) 0%, transparent 70%),
-          linear-gradient(180deg, #f0f9ff 0%, #e0f2fe 100%)
+          radial-gradient(circle at var(--x, 50%) var(--y, 50%), rgba(209, 213, 219, 0.6) 0%, rgba(243, 244, 246, 0.8) 70%),
+          linear-gradient(180deg, #f3f4f6 0%, #e5e7eb 100%)
         `;
 
     case 'none':

--- a/src/utils/particleFactory.ts
+++ b/src/utils/particleFactory.ts
@@ -2,7 +2,7 @@
 import { Particle } from '@/types/particle';
 
 export const createParticle = (x: number, y: number, trackingType: string, backgroundType: string = 'none'): Particle => {
-  const color = getBackgroundAwareColor(backgroundType);
+  const color = getTrackingAwareColor(trackingType) || getBackgroundAwareColor(backgroundType);
   const baseParticle = {
     x,
     y,
@@ -49,15 +49,30 @@ const getBackgroundAwareColor = (backgroundType: string): string => {
       const synthwaveColors = ['#ff1493', '#00ffff', '#ff4500', '#ff69b4', '#ff0080', '#00ff80'];
       return synthwaveColors[Math.floor(Math.random() * synthwaveColors.length)];
     
-    case 'ocean':
-      const oceanColors = ['#00bfff', '#1e90ff', '#0066cc', '#4169e1', '#48d1cc', '#87ceeb'];
-      return oceanColors[Math.floor(Math.random() * oceanColors.length)];
     
     default:
       // Convert HSL to hex format to avoid color parsing issues
       const hue = Math.random() * 360;
       return hslToHex(hue, 70, 60);
   }
+};
+
+const getTrackingAwareColor = (trackingType: string): string | undefined => {
+  const colorsMap: Record<string, string[]> = {
+    subtle: ['#6ee7b7', '#34d399'],
+    comet: ['#93c5fd', '#3b82f6'],
+    fireworks: ['#f9a8d4', '#ec4899'],
+    lightning: ['#fcd34d', '#facc15'],
+    galaxy: ['#c084fc', '#a855f7'],
+    neon: ['#f0abfc', '#d946ef'],
+    watercolor: ['#7dd3fc', '#38bdf8'],
+    geometric: ['#fdba74', '#fb923c'],
+  };
+  const palette = colorsMap[trackingType];
+  if (palette) {
+    return palette[Math.floor(Math.random() * palette.length)];
+  }
+  return undefined;
 };
 
 // Helper function to convert HSL to hex
@@ -126,15 +141,6 @@ const applyBackgroundBehavior = (particle: Particle, backgroundType: string, tra
         energy: particle.energy * 1.5, // Reduced from 2.0
       };
     
-    case 'ocean':
-      return {
-        ...particle,
-        vx: particle.vx + Math.sin(Date.now() * 0.002) * 0.6, // Reduced from 0.8
-        vy: particle.vy + Math.cos(Date.now() * 0.002) * 0.6,
-        maxLife: 3.0, // Reduced from 3.5
-        life: 3.0,
-        size: particle.size * 1.3, // Reduced from 1.6
-      };
     
     default:
       return particle;

--- a/src/utils/particleRenderer.ts
+++ b/src/utils/particleRenderer.ts
@@ -36,9 +36,6 @@ const drawBackgroundSpecificEffects = (ctx: CanvasRenderingContext2D, particle: 
       drawSynthwaveParticle(ctx, particle, alpha);
       break;
     
-    case 'ocean':
-      drawOceanParticle(ctx, particle, alpha);
-      break;
     
     default:
       drawDefaultParticle(ctx, particle, alpha, isDarkMode);
@@ -222,46 +219,6 @@ const drawSynthwaveParticle = (ctx: CanvasRenderingContext2D, particle: Particle
   ctx.restore();
 };
 
-const drawOceanParticle = (ctx: CanvasRenderingContext2D, particle: Particle, alpha: number): void => {
-  ctx.save();
-  ctx.globalAlpha = alpha * 0.9;
-  
-  // Bubble-like effect with wave distortion
-  const time = Date.now() * 0.002;
-  const waveX = Math.sin(time + particle.y * 0.01) * 2;
-  const waveY = Math.cos(time * 0.8 + particle.x * 0.01) * 1.5;
-  
-  // Bubble with refraction
-  const gradient = ctx.createRadialGradient(
-    particle.x + waveX - particle.size * 0.3,
-    particle.y + waveY - particle.size * 0.3,
-    0,
-    particle.x + waveX,
-    particle.y + waveY,
-    particle.size * 3
-  );
-  gradient.addColorStop(0, '#ffffff44');
-  gradient.addColorStop(0.3, particle.color + 'AA');
-  gradient.addColorStop(0.7, particle.color + '44');
-  gradient.addColorStop(1, 'transparent');
-  
-  ctx.fillStyle = gradient;
-  ctx.beginPath();
-  ctx.arc(particle.x + waveX, particle.y + waveY, particle.size * 3, 0, Math.PI * 2);
-  ctx.fill();
-  
-  // Highlight on bubble
-  ctx.fillStyle = '#ffffff66';
-  ctx.beginPath();
-  ctx.arc(
-    particle.x + waveX - particle.size * 0.5,
-    particle.y + waveY - particle.size * 0.5,
-    particle.size * 0.7, 0, Math.PI * 2
-  );
-  ctx.fill();
-  
-  ctx.restore();
-};
 
 const drawDefaultParticle = (ctx: CanvasRenderingContext2D, particle: Particle, alpha: number, isDarkMode: boolean): void => {
   ctx.save();


### PR DESCRIPTION
## Summary
- add new `fluid` option in background settings
- drop the old `ocean` background
- return CSS variable based gradients for the new background
- make `fluid` disable pointer trails and respond to pointer movement
- give each tracking animation a unique color
- update tests for the new background

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684324e04e1883339732c02e41514227