### PR TITLE
Add GitHub Pages PR preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,57 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pages-preview-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      pull-requests: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Live preview: ${{ steps.deployment.outputs.page_url }}`
+            })

--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ Use the Share → Publish option on Lovable to deploy your site. Custom domains 
 
 </details>
 
+
+<details>
+<summary><strong>Previewing Pull Requests</strong></summary>
+
+Every pull request triggers a workflow that builds the site and publishes a free GitHub Pages preview. A link to the preview is posted as a comment on the PR so you can test changes before merging.
+
+</details>
+


### PR DESCRIPTION
## Summary
- create CI workflow to build and deploy a PR preview to GitHub Pages
- document the preview feature in the README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684327237e8c8333b411e09617ea95e1