### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : '/shadow-scroll-blossom/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set correct Vite base path so the site loads when deployed on GitHub Pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843795b3280833381ef19679d2f34e5