### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,9 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: GITHUB_PAGES=true npm run build
+      - run: VITE_DEPLOY_TARGET=github npm run build
         env:
-          GITHUB_PAGES: true
+          VITE_DEPLOY_TARGET: github
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,9 +27,9 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: GITHUB_PAGES=true npm run build
+      - run: VITE_DEPLOY_TARGET=github npm run build
         env:
-          GITHUB_PAGES: true
+          VITE_DEPLOY_TARGET: github
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,28 +9,16 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
-// Dynamically determine base URL based on environment
-const getBasename = () => {
-  // For GitHub Pages deployment
-  if (window.location.hostname === 'ba-calderonmorales.github.io') {
-    return '/shadow-scroll-blossom';
-  }
-  
-  // For Lovable deployments (.lovable.app), use root path
-  if (window.location.hostname.includes('.lovable.app')) {
-    return '/';
-  }
-  
-  // For other deployments, use the Vite base URL
-  return import.meta.env.BASE_URL;
-};
+// Use the Vite `base` value for BrowserRouter's basename. Vite injects the
+// correct base at build time depending on the deployment target.
+const basename = import.meta.env.BASE_URL;
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter basename={getBasename()}>
+      <BrowserRouter basename={basename}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,15 +6,12 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  // Determine base URL based on deployment target
-  let base = '/';
-  
-  if (mode === 'production') {
-    // Check if we're building for GitHub Pages
-    // This can be determined by environment variable or other means
-    const isGitHubPages = process.env.GITHUB_PAGES === 'true' || process.env.CI === 'true';
-    base = isGitHubPages ? '/shadow-scroll-blossom/' : '/';
-  }
+  // Set the base path depending on the deployment target. When deploying to
+  // GitHub Pages we use the repository name as the base. All other environments
+  // (local dev and Lovable previews) should use the root path.
+  const base = process.env.VITE_DEPLOY_TARGET === 'github'
+    ? '/shadow-scroll-blossom/'
+    : '/';
 
   return {
     base,


### PR DESCRIPTION
## Summary
- fix `BrowserRouter` basename to use Vite's base
- determine base using `VITE_DEPLOY_TARGET` env var
- update actions to set `VITE_DEPLOY_TARGET` during build

## Testing
- `npm test`
- `VITE_DEPLOY_TARGET=github npm run build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b5d709a1c8333abe782c62d01d7ae