### PR TITLE
Feature: add ocean background

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ src/
 
 - Mouse and touch interaction on the canvas
 - Multiple particle styles and background themes
+- Includes a new **Ocean** theme with deep blue gradients
 - Dark mode toggle with persistence
 - Settings stored in localStorage
 

--- a/src/data/settingsOptions.ts
+++ b/src/data/settingsOptions.ts
@@ -18,6 +18,7 @@ export const backgroundOptions = [
   { value: 'matrix', label: 'Digital Matrix', description: 'Flowing code patterns' },
   { value: 'aurora', label: 'Aurora Borealis', description: 'Dancing northern lights' },
   { value: 'synthwave', label: 'Synthwave', description: 'Retro 80s neon vibes' },
+  { value: 'ocean', label: 'Ocean', description: 'Deep blue gradients' },
   { value: 'fluid', label: 'Interactive Fluid', description: 'Flowing neutral ripples' }
 ];
 

--- a/src/utils/__tests__/backgroundUtils.test.ts
+++ b/src/utils/__tests__/backgroundUtils.test.ts
@@ -28,4 +28,16 @@ describe('getBackgroundStyle', () => {
     expect(result).toContain('var(--x');
     expect(result).toContain('var(--y');
   });
+
+  test('returns ocean dark style', () => {
+    const result = getBackgroundStyle('ocean', true);
+    expect(result).toContain('linear-gradient');
+    expect(result).toContain('#001022');
+  });
+
+  test('returns ocean light style', () => {
+    const result = getBackgroundStyle('ocean', false);
+    expect(result).toContain('linear-gradient');
+    expect(result).toContain('#e0f7ff');
+  });
 });

--- a/src/utils/backgroundUtils.ts
+++ b/src/utils/backgroundUtils.ts
@@ -79,6 +79,17 @@ export const getBackgroundStyle = (backgroundType: string, isDarkMode: boolean):
           linear-gradient(180deg, #fdf4ff 0%, #f3e8ff 100%)
         `;
 
+    case 'ocean':
+      return isDarkMode
+        ? `
+          radial-gradient(circle at 50% 50%, rgba(0, 90, 150, 0.4) 0%, transparent 70%),
+          linear-gradient(180deg, #001022 0%, #004466 100%)
+        `
+        : `
+          radial-gradient(circle at 50% 50%, rgba(0, 120, 200, 0.3) 0%, transparent 70%),
+          linear-gradient(180deg, #e0f7ff 0%, #a0d8f0 100%)
+        `;
+
     case 'fluid':
       return isDarkMode
         ? `
@@ -106,6 +117,8 @@ export const getBackgroundSize = (backgroundType: string): string => {
       return '100% 100%, 100% 100%, 100% 100%, 25px 25px, 25px 25px, 100% 100%';
     case 'synthwave':
       return '100% 100%, 100% 100%, 100% 100%, 20px 20px, 20px 20px, 100% 100%';
+    case 'ocean':
+      return '100% 100%, 100% 100%';
     default:
       return '100% 100%';
   }


### PR DESCRIPTION
## Summary
- add new `ocean` background option
- document new theme in the README
- test background utility for the new theme

## Codex CI
- `npm ci`
- `npm test`
- `npm run build`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68600e9b4b9483339dd18aada9eba283