### PR TITLE
Feature: add sunset background theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ src/
 - Includes a new **Ocean** theme with deep blue gradients
 - Introduces a **Desert** theme with warm sand tones
 - Adds a **Forest** theme with lush green hues
+- Adds a **Sunset** theme with orange-to-purple hues
 - Dark mode toggle with persistence
 - Settings stored in localStorage
 

--- a/src/data/settingsOptions.ts
+++ b/src/data/settingsOptions.ts
@@ -21,6 +21,7 @@ export const backgroundOptions = [
   { value: 'ocean', label: 'Ocean', description: 'Deep blue gradients' },
   { value: 'desert', label: 'Desert Mirage', description: 'Warm sandy gradients' },
   { value: 'forest', label: 'Forest', description: 'Lush green gradients' },
+  { value: 'sunset', label: 'Sunset', description: 'Warm orange to purple gradient' },
   { value: 'fluid', label: 'Interactive Fluid', description: 'Flowing neutral ripples' }
 ];
 

--- a/src/utils/__tests__/backgroundUtils.test.ts
+++ b/src/utils/__tests__/backgroundUtils.test.ts
@@ -60,4 +60,14 @@ describe('getBackgroundStyle', () => {
     const result = getBackgroundStyle('forest', false);
     expect(result).toContain('#e6ffe6');
   });
+
+  test('returns sunset dark style', () => {
+    const result = getBackgroundStyle('sunset', true);
+    expect(result).toContain('#552218');
+  });
+
+  test('returns sunset light style', () => {
+    const result = getBackgroundStyle('sunset', false);
+    expect(result).toContain('#ffdfc0');
+  });
 });

--- a/src/utils/backgroundUtils.ts
+++ b/src/utils/backgroundUtils.ts
@@ -112,6 +112,17 @@ export const getBackgroundStyle = (backgroundType: string, isDarkMode: boolean):
           linear-gradient(180deg, #e6ffe6 0%, #b3ffb3 100%)
         `;
 
+    case 'sunset':
+      return isDarkMode
+        ? `
+          radial-gradient(circle at 50% 50%, rgba(255, 100, 0, 0.4) 0%, transparent 70%),
+          linear-gradient(180deg, #552218 0%, #120b2a 100%)
+        `
+        : `
+          radial-gradient(circle at 50% 50%, rgba(255, 150, 0, 0.3) 0%, transparent 70%),
+          linear-gradient(180deg, #ffdfc0 0%, #ffd1d1 100%)
+        `;
+
     case 'fluid':
       return isDarkMode
         ? `
@@ -144,6 +155,8 @@ export const getBackgroundSize = (backgroundType: string): string => {
     case 'desert':
       return '100% 100%, 100% 100%';
     case 'forest':
+      return '100% 100%, 100% 100%';
+    case 'sunset':
       return '100% 100%, 100% 100%';
     default:
       return '100% 100%';


### PR DESCRIPTION
## Summary
- add `sunset` background option
- support `sunset` in background utilities
- test new theme styles
- document new theme in README

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686030bbc7ec833399c7298aeab93bf3