### PR TITLE
Bugfix: adjust tracking particle colors

### DIFF
--- a/src/utils/__tests__/colorUtils.test.ts
+++ b/src/utils/__tests__/colorUtils.test.ts
@@ -1,0 +1,13 @@
+import { getComplementaryHex, blendHexColors } from '../colorUtils';
+
+describe('color utilities', () => {
+  test('creates complementary color', () => {
+    const comp = getComplementaryHex('#00ff00');
+    expect(comp.toLowerCase()).toBe('#ff00ff');
+  });
+
+  test('blends two colors', () => {
+    const blended = blendHexColors('#ff0000', '#0000ff');
+    expect(blended.toLowerCase()).toBe('#800080');
+  });
+});

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,0 +1,76 @@
+export const hexToRgb = (hex: string): { r: number; g: number; b: number } => {
+  let sanitized = hex.replace('#', '');
+  if (sanitized.length === 3) {
+    sanitized = sanitized.split('').map((c) => c + c).join('');
+  }
+  const num = parseInt(sanitized, 16);
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255,
+  };
+};
+
+export const rgbToHex = (r: number, g: number, b: number): string => {
+  const toHex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+export const blendHexColors = (hex1: string, hex2: string): string => {
+  const c1 = hexToRgb(hex1);
+  const c2 = hexToRgb(hex2);
+  const r = Math.round((c1.r + c2.r) / 2);
+  const g = Math.round((c1.g + c2.g) / 2);
+  const b = Math.round((c1.b + c2.b) / 2);
+  return rgbToHex(r, g, b);
+};
+
+export const hexToHsl = (hex: string): { h: number; s: number; l: number } => {
+  const { r, g, b } = hexToRgb(hex);
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm:
+        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
+        break;
+      case gNorm:
+        h = (bNorm - rNorm) / d + 2;
+        break;
+      default:
+        h = (rNorm - gNorm) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+};
+
+export const hslToHex = (h: number, s: number, l: number): string => {
+  l /= 100;
+  const a = (s * Math.min(l, 1 - l)) / 100;
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+};
+
+export const getComplementaryHex = (hex: string): string => {
+  const { h, s, l } = hexToHsl(hex);
+  return hslToHex((h + 180) % 360, s, l);
+};

--- a/src/utils/particleFactory.ts
+++ b/src/utils/particleFactory.ts
@@ -1,8 +1,12 @@
 
 import { Particle } from '@/types/particle';
+import { blendHexColors, getComplementaryHex, hslToHex } from './colorUtils';
 
 export const createParticle = (x: number, y: number, trackingType: string, backgroundType: string = 'none'): Particle => {
-  const color = getTrackingAwareColor(trackingType) || getBackgroundAwareColor(backgroundType);
+  const trackingColor = getTrackingAwareColor(trackingType);
+  const backgroundColor = getBackgroundAwareColor(backgroundType);
+  const complementary = getComplementaryHex(backgroundColor);
+  const color = trackingColor ? blendHexColors(trackingColor, complementary) : complementary;
   const baseParticle = {
     x,
     y,
@@ -75,17 +79,6 @@ const getTrackingAwareColor = (trackingType: string): string | undefined => {
   return undefined;
 };
 
-// Helper function to convert HSL to hex
-const hslToHex = (h: number, s: number, l: number): string => {
-  l /= 100;
-  const a = s * Math.min(l, 1 - l) / 100;
-  const f = (n: number) => {
-    const k = (n + h / 30) % 12;
-    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color).toString(16).padStart(2, '0');
-  };
-  return `#${f(0)}${f(8)}${f(4)}`;
-};
 
 const applyBackgroundBehavior = (particle: Particle, backgroundType: string, trackingType: string): Particle => {
   switch (backgroundType) {


### PR DESCRIPTION
## Summary
- color utilities for hex conversions and blending
- tracking particle color now complements the selected background
- tests for color utilities

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68603cb3209c83339119ad74afade0ad