### PR TITLE
Feature: add midnight background theme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
       - run: VITE_DEPLOY_TARGET=github npm run build
         env:
           VITE_DEPLOY_TARGET: github

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
       - run: VITE_DEPLOY_TARGET=github npm run build
         env:
           VITE_DEPLOY_TARGET: github

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ src/
 - Introduces a **Desert** theme with warm sand tones
 - Adds a **Forest** theme with lush green hues
 - Adds a **Sunset** theme with orange-to-purple hues
+- Adds a **Midnight** theme with deep indigo blues
 - Dark mode toggle with persistence
 - Settings stored in localStorage
 

--- a/src/data/settingsOptions.ts
+++ b/src/data/settingsOptions.ts
@@ -22,6 +22,7 @@ export const backgroundOptions = [
   { value: 'desert', label: 'Desert Mirage', description: 'Warm sandy gradients' },
   { value: 'forest', label: 'Forest', description: 'Lush green gradients' },
   { value: 'sunset', label: 'Sunset', description: 'Warm orange to purple gradient' },
+  { value: 'midnight', label: 'Midnight', description: 'Deep indigo tones' },
   { value: 'fluid', label: 'Interactive Fluid', description: 'Flowing neutral ripples' }
 ];
 

--- a/src/utils/__tests__/backgroundUtils.test.ts
+++ b/src/utils/__tests__/backgroundUtils.test.ts
@@ -70,4 +70,14 @@ describe('getBackgroundStyle', () => {
     const result = getBackgroundStyle('sunset', false);
     expect(result).toContain('#ffdfc0');
   });
+
+  test('returns midnight dark style', () => {
+    const result = getBackgroundStyle('midnight', true);
+    expect(result).toContain('#0b1236');
+  });
+
+  test('returns midnight light style', () => {
+    const result = getBackgroundStyle('midnight', false);
+    expect(result).toContain('#dde7ff');
+  });
 });

--- a/src/utils/backgroundUtils.ts
+++ b/src/utils/backgroundUtils.ts
@@ -123,6 +123,17 @@ export const getBackgroundStyle = (backgroundType: string, isDarkMode: boolean):
           linear-gradient(180deg, #ffdfc0 0%, #ffd1d1 100%)
         `;
 
+    case 'midnight':
+      return isDarkMode
+        ? `
+          radial-gradient(circle at 50% 50%, rgba(40, 40, 70, 0.4) 0%, transparent 70%),
+          linear-gradient(180deg, #0b1236 0%, #000011 100%)
+        `
+        : `
+          radial-gradient(circle at 50% 50%, rgba(90, 100, 160, 0.3) 0%, transparent 70%),
+          linear-gradient(180deg, #dde7ff 0%, #a1b5ff 100%)
+        `;
+
     case 'fluid':
       return isDarkMode
         ? `
@@ -157,6 +168,8 @@ export const getBackgroundSize = (backgroundType: string): string => {
     case 'forest':
       return '100% 100%, 100% 100%';
     case 'sunset':
+      return '100% 100%, 100% 100%';
+    case 'midnight':
       return '100% 100%, 100% 100%';
     default:
       return '100% 100%';


### PR DESCRIPTION
## Summary
- introduce a new Midnight background theme and options
- test the Midnight style generation
- run tests and type checks in preview and deploy workflows

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860503dc9fc8333993f3fc08c1ad782