### PR TITLE
Feature: new color lightness helpers

### DIFF
--- a/src/utils/__tests__/colorUtils.test.ts
+++ b/src/utils/__tests__/colorUtils.test.ts
@@ -1,4 +1,9 @@
-import { getComplementaryHex, blendHexColors } from '../colorUtils';
+import {
+  getComplementaryHex,
+  blendHexColors,
+  lightenHex,
+  darkenHex,
+} from '../colorUtils';
 
 describe('color utilities', () => {
   test('creates complementary color', () => {
@@ -9,5 +14,15 @@ describe('color utilities', () => {
   test('blends two colors', () => {
     const blended = blendHexColors('#ff0000', '#0000ff');
     expect(blended.toLowerCase()).toBe('#800080');
+  });
+
+  test('lightens a color', () => {
+    const lighter = lightenHex('#333333', 20);
+    expect(lighter.toLowerCase()).toBe('#666666');
+  });
+
+  test('darkens a color', () => {
+    const darker = darkenHex('#ffffff', 20);
+    expect(darker.toLowerCase()).toBe('#cccccc');
   });
 });

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -74,3 +74,15 @@ export const getComplementaryHex = (hex: string): string => {
   const { h, s, l } = hexToHsl(hex);
   return hslToHex((h + 180) % 360, s, l);
 };
+
+export const adjustHexLightness = (hex: string, amount: number): string => {
+  const { h, s, l } = hexToHsl(hex);
+  const newL = Math.max(0, Math.min(100, l + amount));
+  return hslToHex(h, s, newL);
+};
+
+export const lightenHex = (hex: string, amount: number): string =>
+  adjustHexLightness(hex, Math.abs(amount));
+
+export const darkenHex = (hex: string, amount: number): string =>
+  adjustHexLightness(hex, -Math.abs(amount));

--- a/src/utils/particleFactory.ts
+++ b/src/utils/particleFactory.ts
@@ -1,6 +1,12 @@
 
 import { Particle } from '@/types/particle';
-import { blendHexColors, getComplementaryHex, hslToHex } from './colorUtils';
+import {
+  blendHexColors,
+  getComplementaryHex,
+  hslToHex,
+  lightenHex,
+  darkenHex,
+} from './colorUtils';
 
 export const createParticle = (x: number, y: number, trackingType: string, backgroundType: string = 'none'): Particle => {
   const trackingColor = getTrackingAwareColor(trackingType);
@@ -132,6 +138,22 @@ const applyBackgroundBehavior = (particle: Particle, backgroundType: string, tra
         life: 2.5,
         size: particle.size * 1.1, // Reduced from 1.2
         energy: particle.energy * 1.5, // Reduced from 2.0
+      };
+
+    case 'sunset':
+      return {
+        ...particle,
+        color: lightenHex(particle.color, 20),
+        vx: particle.vx * 0.7,
+        vy: particle.vy * 0.7,
+      };
+
+    case 'midnight':
+      return {
+        ...particle,
+        color: darkenHex(particle.color, 15),
+        vx: particle.vx * 0.5,
+        vy: particle.vy * 0.5,
       };
     
     


### PR DESCRIPTION
## Summary
- add lightness utilities to `colorUtils`
- apply lightening/darkening in particle factory for sunset and midnight backgrounds
- test new color helpers

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686293badf0c83339341ef04cecc619a